### PR TITLE
Refactor how verifiers are created and handled

### DIFF
--- a/src/main/java/base/MainProgram.java
+++ b/src/main/java/base/MainProgram.java
@@ -10,6 +10,8 @@ import com.github.javaparser.ast.CompilationUnit;
 
 import org.gradle.api.GradleException;
 import patternverifiers.Feedback;
+import patternverifiers.IPatternGroupVerifier;
+import patternverifiers.VerifierFactory;
 
 /**
  * The main entry point for the analysis.
@@ -36,7 +38,6 @@ public final class MainProgram {
      *
      * @param paths an array of paths to analyse.
      */
-    @SuppressWarnings("PMD.SystemPrintln")
     public static void startAnalyse(String[] paths) {
         AnnotationVisitor visitor = new AnnotationVisitor();
         for (String path : paths) {
@@ -54,7 +55,8 @@ public final class MainProgram {
             .entrySet()) {
             PatternGroup group = entry.getKey();
             Map<Pattern, List<CompilationUnit>> patternMap = entry.getValue();
-            Feedback verFeedback = group.getVerifier().verifyGroup(patternMap);
+            IPatternGroupVerifier verifier = VerifierFactory.createGroupVerifier(group);
+            Feedback verFeedback = verifier.verifyGroup(patternMap);
             feedbacks.add(verFeedback);
         }
 

--- a/src/main/java/base/PatternGroup.java
+++ b/src/main/java/base/PatternGroup.java
@@ -1,24 +1,10 @@
 package base;
 
-import patternverifiers.IPatternGroupVerifier;
-import patternverifiers.ImmutableVerifier;
-import patternverifiers.SingleClassVerifier;
-import patternverifiers.SingletonVerifier;
-
 /**
  * A design pattern covering all parts of that pattern..
  */
 public enum PatternGroup {
-    SINGLETON(new SingleClassVerifier(new SingletonVerifier())),
-    IMMUTABLE(new SingleClassVerifier(new ImmutableVerifier()));
+    SINGLETON,
+    IMMUTABLE
 
-    private IPatternGroupVerifier verifier;
-
-    PatternGroup(IPatternGroupVerifier groupVerifier) {
-        verifier = groupVerifier;
-    }
-
-    IPatternGroupVerifier getVerifier() {
-        return verifier;
-    }
 }

--- a/src/main/java/patternverifiers/VerifierFactory.java
+++ b/src/main/java/patternverifiers/VerifierFactory.java
@@ -23,7 +23,7 @@ public final class VerifierFactory {
                 return new SingleClassVerifier(new SingletonVerifier());
             default:
                 throw new IllegalArgumentException(
-                    "The avaliable pattergroups and the factory " + "does not match.");
+                    "The avaliable pattergroups and the factory does not match.");
         }
     }
 }

--- a/src/main/java/patternverifiers/VerifierFactory.java
+++ b/src/main/java/patternverifiers/VerifierFactory.java
@@ -1,0 +1,29 @@
+package patternverifiers;
+
+import base.PatternGroup;
+
+/**
+ * Factory for creating Verifiers.
+ */
+public final class VerifierFactory {
+
+    private VerifierFactory() {
+    }
+
+    /**
+     * Factory method for IPatternGroupVerifiers.
+     * @param verifierType the type of the desired verifier
+     */
+    public static IPatternGroupVerifier createGroupVerifier(PatternGroup verifierType) {
+
+        switch (verifierType) {
+            case IMMUTABLE:
+                return new SingleClassVerifier(new ImmutableVerifier());
+            case SINGLETON:
+                return new SingleClassVerifier(new SingletonVerifier());
+            default:
+                throw new IllegalArgumentException(
+                    "The avaliable pattergroups and the factory " + "does not match.");
+        }
+    }
+}


### PR DESCRIPTION
We noticed that we exposed our verifiers to the user through the Enums PatternGroup. 
```
Patterngroup.IMMUTABLE.getVerifier()
```
The refactor means that a to create a new verifier you have to:
* Create a Class implementing the Interface IPatternGroupVerifier
* Create a PatternGroup ~~and add your verifier to its constructor~~
* Create the sub-patterns in Pattern and reference your PatternsGroup
* **Add a switch-case in the VerifierFactory for your PatternGroup** 